### PR TITLE
Casmuser 2720

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-vault
-version: 1.1.0
+version: 1.2.0
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -17,6 +17,9 @@ allowedAuthNamespaces:
   - namespace: services
     serviceaccount: "*"
     ttl: 72h
+  - namespace: uas
+    serviceaccount: "*"
+    ttl: 72h
 
 vault:
   ui: false


### PR DESCRIPTION
## Summary and Scope

Add the uas namespace to allowedAuthNamespaces in cray-vault so that Broker UAIs can use vault to share host and internal keys among replicas and between restarts.

This change is backwards compatible.

## Issues and Related PRs

* Future work required by [CASMUSER-2720](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2720)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Ran vault on vshasta with this change, verified that vshasta behaved as expected and that Broker UAIs could store, retrieve and delete their secrets from vault.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

There are no known risks associated with this change.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

