### PR TITLE
CASMPET-5745 Fix k8s auth for k8s 1.21+

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-vault
-version: 1.2.0
+version: 1.3.0
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -16,7 +16,7 @@ spec:
     backup.velero.io/backup-volumes: vault-raft
   veleroEnabled: true
   veleroFsfreezeImage: "{{ .Values.vault.veleroFsfreezeImage }}"
-  
+
   {{- if .Values.vault.antiaffinity.enabled }}
   podAntiAffinity: {{ .Values.vault.antiaffinity.topologyKey }}
   {{- end }}
@@ -148,6 +148,9 @@ spec:
       {{- end }}
     auth:
       - type: kubernetes
+        config:
+          # This is required for Kubernetes 1.21+
+          issuer: "https://kubernetes.default.svc.cluster.local"
         roles:
           {{- if .Values.pki.customCA.enabled }}
           # authN role used by cert-manager for 'common', namespace-bound issuers


### PR DESCRIPTION
## Summary and Scope

Kubernetes 1.21+ updated the kubernetes serviceaccount JWT ISS, breaking kubernetes token access to vault. This updates the issuer in vault, which fixes the issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5745](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5745)
* 
## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that spire-intermediate was able to talk to vault after the update.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations



## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

