### PR TITLE
Add slurm-operator

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -1,6 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: cray-vault
-version: 1.3.1
+version: 1.3.2
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -1,3 +1,26 @@
+{{/*
+MIT License
+
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
 apiVersion: "vault.banzaicloud.com/v1alpha1"
 kind: "Vault"
 metadata:
@@ -164,6 +187,7 @@ spec:
               - istio-system
               - sma
               - tapms-operator
+              - slurm-operator
               - spire
             policies:
               - pki-common

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 ---
 # Default values for cray-vault.
 # This is a YAML-formatted file.
@@ -19,6 +42,9 @@ allowedAuthNamespaces:
     ttl: 72h
   - namespace: uas
     serviceaccount: "*"
+    ttl: 72h
+  - namespace: slurm-operator
+    serviceaccount: "slurm-operator"
     ttl: 72h
 
 vault:


### PR DESCRIPTION
## Summary and Scope

Fix for slurm-operator writing munge keys to vault from slurm-operator namespace.

## Issues and Related PRs

* Resolves [CASMPET-5953](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5953)

## Testing

```
ncn-m001-cdd6e862:/home/bklein/demo # kubectl get vault -n vault -o yaml | grep -C6 slurm
          bound_service_account_namespaces:
          - ceph-rgw
          - services
          - istio-system
          - sma
          - tapms-operator
          - slurm-operator
          - spire
          name: pki-common
          policies:
          - pki-common
          ttl: 1h
        - bound_service_account_names:
--
          name: uas
          policies:
          - allow_secrets
          - allow_transit
          ttl: 72h
        - bound_service_account_names:
          - slurm-operator
          bound_service_account_namespaces:
          - slurm-operator
          name: slurm-operator
          policies:
          - allow_secrets
          - allow_transit
          ttl: 72h
        type: kubernetes
      policies:
```

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

