### PR TITLE
CASMPET-6151 Update versions

### DIFF
--- a/charts/cray-vault-operator/Chart.yaml
+++ b/charts/cray-vault-operator/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 name: cray-vault-operator
-version: 1.1.1
+version: 1.2.0
 description: Cray Vault Operator for secure secret stores
 keywords:
   - cray-vault-operator
 home: "cloud/cray-charts"
 dependencies:
   - name: vault-operator
-    version: 1.8.0
+    version: 1.16.2
     repository: https://kubernetes-charts.banzaicloud.com
 maintainers:
   - name: kburns-hpe
-appVersion: 1.8.0  # Tracks the upstream version of vault-operator
+appVersion: 1.16.0  # Tracks the upstream version of vault-operator
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -25,7 +25,7 @@ annotations:
     - name: kubectl
       image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
     - name: vault-operator
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/vault-operator:1.8.0
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/vault-operator:1.16.0
     - name: bank-vaults
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.8.0
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.16.0
   artifacthub.io/license: MIT

--- a/charts/cray-vault-operator/Chart.yaml
+++ b/charts/cray-vault-operator/Chart.yaml
@@ -7,11 +7,11 @@ keywords:
 home: "cloud/cray-charts"
 dependencies:
   - name: vault-operator
-    version: 1.16.2
+    version: 1.16.1
     repository: https://kubernetes-charts.banzaicloud.com
 maintainers:
   - name: kburns-hpe
-appVersion: 1.16.0  # Tracks the upstream version of vault-operator
+appVersion: 1.16.0 # Tracks the upstream version of vault-operator
 annotations:
   artifacthub.io/changes: |
     - kind: security

--- a/charts/cray-vault-operator/values.yaml
+++ b/charts/cray-vault-operator/values.yaml
@@ -12,7 +12,7 @@ vault-operator:
   image:
     bankVaultsRepository: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults
     repository: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/vault-operator
-    tag: 1.8.0
+    tag: 1.16.0
 
   watchNamespace: "vault"
 

--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,14 +23,14 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.3.2
+version: 1.4.0
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault
 home: https://github.com/Cray-HPE/cray-vault
 maintainers:
   - name: kburns-hpe
-appVersion: 1.5.5
+appVersion: 1.12.1
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -46,9 +46,9 @@ annotations:
     - name: ubuntu
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/ubuntu:focal
     - name: vault
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.5.5
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.12.1
     - name: bank-vaults
-      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.8.0
+      image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.16.0
     - name: statsd-exporter
       image: artifactory.algol60.net/csm-docker/stable/docker.io/prom/statsd-exporter:v0.18.0
   artifacthub.io/license: MIT

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -72,7 +72,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.raft.pvc.storage }}
-        persistentVolumeReclaimPolicy: Retain
     {{- if .Values.audit.enabled }}
     - metadata:
         name: vault-audit
@@ -81,7 +80,6 @@ spec:
         # storageClassName: ""
         accessModes:
         - {{ .Values.audit.pvc.accessMode }}
-        persistentVolumeReclaimPolicy: Retain
         resources:
           requests:
             storage: {{ .Values.audit.pvc.storage }}

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -50,8 +50,8 @@ allowedAuthNamespaces:
 vault:
   ui: false
   size: 3
-  image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.5.5"
-  bankVaultsImage: "artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.8.0"
+  image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.12.1"
+  bankVaultsImage: "artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.16.0"
   statsdImage: "artifactory.algol60.net/csm-docker/stable/docker.io/prom/statsd-exporter:v0.18.0"
   veleroFsfreezeImage: "artifactory.algol60.net/csm-docker/stable/docker.io/library/ubuntu:focal"
   antiaffinity:


### PR DESCRIPTION


## Summary and Scope

- Update vault to 1.12.1
- Update vault-operator to 1.16.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6151 ](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6151 )

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Adeed test data into vault. Validated that data was accessible after both upgrading and downgrading vault and the vault-operator

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

When vault is downgraded the `--pre-flight-checks` needs to be manually removed from command line options in the cray-vault-configurer deployment. If this isn't removed then the pod will crash due to this not being a valid option in bank-vaults 1.8.0.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

