### PR TITLE
CASMINST-5623 Downgrade vault to 1.10.8

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,14 +23,14 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.4.0
+version: 1.4.1
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault
 home: https://github.com/Cray-HPE/cray-vault
 maintainers:
   - name: kburns-hpe
-appVersion: 1.12.1
+appVersion: 1.10.8
 annotations:
   artifacthub.io/changes: |
     - kind: security
@@ -46,7 +46,7 @@ annotations:
     - name: ubuntu
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/ubuntu:focal
     - name: vault
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.12.1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.10.8
     - name: bank-vaults
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.16.0
     - name: statsd-exporter

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -50,7 +50,7 @@ allowedAuthNamespaces:
 vault:
   ui: false
   size: 3
-  image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.12.1"
+  image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/vault:1.10.8"
   bankVaultsImage: "artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/bank-vaults:1.16.0"
   statsdImage: "artifactory.algol60.net/csm-docker/stable/docker.io/prom/statsd-exporter:v0.18.0"
   veleroFsfreezeImage: "artifactory.algol60.net/csm-docker/stable/docker.io/library/ubuntu:focal"


### PR DESCRIPTION
## Summary and Scope

vault 1.12.1 does not work on fresh installs with the latest bank-vaults. We'll need to use 1.10.8 instead. This version is still supported by hashicorp.

## Issues and Related PRs


* Resolves [CASMINST-5623](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5623)

## Testing

### Tested on:

  * drax
### Test description:

Validated vault came up properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? n, already done in previous testing
- Was downgrade tested? If not, why? n, already done in previous testing
- Were new tests (or test issues/Jiras) created for this change? n
## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

