### PR TITLE
CASMPET-6230 Add permissions for tpm-intermediate

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.4.1
+version: 1.5.0
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -156,6 +156,11 @@ spec:
       # path == pki-mount/action
       - name: spire-intermediate
         rules: path "pki_common/root/sign-intermediate" { capabilities = ["update"] }
+      # This pki-engine policy is used by tpm-intermediate to request an intermediate CA
+      # certificate for tpm provisioner
+      # path == pki-mount/action
+      - name: tpm-intermediate
+        rules: path "pki_common/root/sign-intermediate" { capabilities = ["update"] }
       {{- end }}
       # This ssh-engine policy is used by services requesting SSH pub key signatures
       # for SSH certs, from vault
@@ -209,6 +214,16 @@ spec:
               - vault
             policies:
               - spire-intermediate
+            ttl: 1h
+          # authN role for direct vault API intermediate CA signing requests
+          # for the tpm-intermediate container
+          - name: tpm-intermediate
+            bound_service_account_names:
+              - "tpm-intermediate"
+            bound_service_account_namespaces:
+              - vault
+            policies:
+              - tpm-intermediate
             ttl: 1h
           {{- end }}
           {{- if .Values.ssh.certs.enabled }}


### PR DESCRIPTION
## Summary and Scope

This adds permissions to allow tpm-intermediate access to request an intermediate cert for use with TPM-Provisioner

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6230](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6230)

## Testing


### Tested on:

  * Loki
### Test description:

Validated tpm-intermediate was able to request a certificate for TPM-Provisioner

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

