### PR TITLE
CASMPET-6520 Add policy to enable TAPMS to work with Vault

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,13 +23,14 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.5.0
+version: 1.6.0
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault
 home: https://github.com/Cray-HPE/cray-vault
 maintainers:
   - name: kburns-hpe
+  - name: rnoska-hpe
 appVersion: 1.10.8
 annotations:
   artifacthub.io/changes: |

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -138,6 +138,15 @@ spec:
         rules: path "transit/*" {
           capabilities = ["create", "read", "update", "delete", "list"]
           }
+      # This policy is used by the Tenant and Partition Management System (TAPMS)
+      # K8s operator to work with tenant transit engine and transit engine keys.
+      # The minimum policy requirements at this time are:
+      # sys/mounts/cray-tenant-* capabilities to permit the creation and removal of tenant transit engines.
+      # cray-tenant-* capabilities to permit the creation and removal of tenant transit engine keys.
+      - name: tapms-operator
+        rules: |
+          path "sys/mounts/cray-tenant-*" { capabilities = ["read", "update", "delete"] }
+          path "cray-tenant-*" { capabilities = ["read", "update", "delete"] }
       {{- if .Values.pki.customCA.enabled }}
       # This pki-engine policy is used by cert-manager for 'common' issuers
       # to request leaf certificate signing
@@ -178,6 +187,18 @@ spec:
           # This is required for Kubernetes 1.21+
           disable_iss_validation: true
         roles:
+          # authN role for the TAPMS operator running in the
+          # cray-tapms-operator pod in the tapms-operator namespace.
+          # Since a Vault token is retrieved for each tenant operation, the
+          # token TTL can be very short.
+          - name: tapms-operator
+            bound_service_account_names:
+              - cray-tapms-operator
+            bound_service_account_namespaces:
+              - tapms-operator
+            policies:
+              - tapms-operator
+            ttl: 5m
           {{- if .Values.pki.customCA.enabled }}
           # authN role used by cert-manager for 'common', namespace-bound issuers
           # via pki-common mount


### PR DESCRIPTION
## Summary and Scope

The tenancy cray-tapms-operator will need the ability to interact with Vault for the creation and removal of tenant-specific Vault transit engines and secrets. This policy addition allows Vault the minimal required permissions to perform those tasks for tenant owned transit resources.

## Issues and Related PRs

* Resolves [CASMPET-6250](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6520)

## Testing

This policy and chart have been tested on VShasta's Ashton with the coming changes to the cray-tapms-operator for the new tenant Vault functionality.

### Tested on:

  * Virtual Shasta (Ashton)

### Test description:

Both manual and via Helm. Both Helm upgrade and fresh install were tested. 

- Was upgrade tested? If not, why? YES
- Was downgrade tested? If not, why? YES

## Risks and Mitigations

Really none, this is adding a policy specific to TAPMS which is not in use yet.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

