### PR TITLE
Add extra init container to ensure /vault/config has the correct permissions for the vault pod"

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.6.0
+version: 1.6.1
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -60,6 +60,12 @@ spec:
         cpu: 500m
         memory: 768Mi
 
+  # Depending on what the container platform is configured to use, init containers may run under
+  # a different user than the actual vault pod leading to EPERM issues with the files the init
+  # container setup.
+  # Ref: https://github.com/bank-vaults/vault-operator/blob/1a25066ab22cfef78ac0172e1f5af8220e277196/deploy/examples/cr-raft.yaml#L74-L86
+  vaultInitContainers: {{- .Values.vault.vaultInitContainers | toYaml | nindent 4 }}
+
   volumeClaimTemplates:
     - metadata:
         name: vault-raft

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -57,6 +57,21 @@ vault:
   antiaffinity:
     enabled: true
     topologyKey: "kubernetes.io/hostname"
+  # This works around an upstream banzai bank vaults issue if the init container
+  # runs under a different context than the vault pods.
+  #
+  # Comment out if unneeded or causing issues, should be unnecessary generally.
+  vaultInitContainers:
+    - name: vault-config-permissions
+      image: "artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.16"
+      command:
+        - /bin/sh
+        - -c
+        - |
+          chown -R 100:1000 /vault/config
+      volumeMounts:
+        - name: vault-config
+          mountPath: /vault/config
 
 audit:
   enabled: false


### PR DESCRIPTION
- CASMTRIAGE-6184: Update vault to add init container to ensure correct permissions for /vault/config
- Bump cray-vault to 1.6.1

## Summary and Scope

As noted in the pr, if an init container starts under a different context than the vault pod, we can see EPERM errors.

I haven't yet tracked down how/where nobody comes into play for the init container that creates /vault/config/config.json, but it mostly doesn't matter. We want the main vault pod to always work.

If this causes issues we can simply not pass in or override the defaults to unset the init container added.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested out on beau for the past 2 days. Tested with this in place, and with a values.yaml without the key at all. Both work though beau wasn't exhibiting the behavior beforehand.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

see above

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? n/a
- Were continuous integration tests run? If not, why? n/a
- Was upgrade tested? If not, why? yes, but if it was wrong the helm install wouldn't have worked anyway.
- Was downgrade tested? If not, why? n/a its basically the same helm chart and you can downgrade like normal
- Were new tests (or test issues/Jiras) created for this change? no

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

