### PR TITLE
Add in vault access through istio

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.6.1
+version: 1.6.2
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/templates/ingress.yaml
+++ b/charts/cray-vault/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{/*
+MIT License
+
+(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: "cray-vault"
+spec:
+  hosts:
+    - "*"
+  {{- with .Values.ingress.gateways }}
+  gateways:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  http:
+    - match:
+      - uri:
+          prefix: /apis/vault
+      rewrite:
+        uri: ' '
+      route:
+      - destination:
+          host: cray-vault
+          port:
+            number: 8200

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -144,6 +144,11 @@ spec:
         rules: path "transit/*" {
           capabilities = ["create", "read", "update", "delete", "list"]
           }
+      # Enable broad access to the sops transist engine
+      - name: allow_sops
+        rules: path "sops/*" {
+          capabilities = ["create", "read", "update", "delete", "list"]
+          }
       # This policy is used by the Tenant and Partition Management System (TAPMS)
       # K8s operator to work with tenant transit engine and transit engine keys.
       # The minimum policy requirements at this time are:
@@ -271,7 +276,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- range .Values.allowedAuthNamespaces }}
-          # authN role that (by policy) allows broad access to secrets and transit engine
+          # authN role that (by policy) allows broad access to secrets, transit engine, and sops transit engine
           - name: {{ .namespace | quote }}
             bound_service_account_names:
               - {{ .serviceaccount | quote }}
@@ -280,6 +285,7 @@ spec:
             policies:
               - allow_secrets
               - allow_transit
+              - allow_sops
             ttl: {{ .ttl }}
           {{- end }}
       {{- if .Values.jwt.enabled }}
@@ -316,6 +322,9 @@ spec:
       - path: transit
         type: transit
         description: Transit Engine
+      - path: sops
+        type: transit
+        description: Sops Transit Engine
       {{- if .Values.pki.customCA.enabled }}
       # This configures PKI instances within vault
       - path: pki_common

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -34,6 +34,12 @@ kubectl:
     tag: 1.19.15
     pullPolicy: IfNotPresent
 
+# Ingress gateways to allow vault access over
+ingress:
+  gateways:
+    - "services/services-gateway"
+    - "services/customer-admin-gateway"
+
 serviceAccountName: "vault"
 
 allowedAuthNamespaces:


### PR DESCRIPTION
## Summary and Scope

This adds in a new virtual service to allow vault access through the istio ingress gateways. This also adds in a new transit engine for use in the SOPs tooling to allow encrypting and decrypting secrets for use in ansible plays.

## Issues and Related PRs

* Resolves [CASMPET-7072](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7072)

## Testing

### Tested on:

  * beau

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

