### PR TITLE
CASMPET-7221 update docker-kubectl version to 1.24.17

### DIFF
--- a/charts/cray-vault-operator/Chart.yaml
+++ b/charts/cray-vault-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-vault-operator
-version: 1.3.0
+version: 1.4.0
 description: Cray Vault Operator for secure secret stores
 keywords:
   - cray-vault-operator
@@ -23,7 +23,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-vault/pull/2
   artifacthub.io/images: |
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
     - name: vault-operator
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/banzaicloud/vault-operator:1.16.0
     - name: bank-vaults

--- a/charts/cray-vault-operator/values.yaml
+++ b/charts/cray-vault-operator/values.yaml
@@ -5,7 +5,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent
 
 vault-operator:

--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.6.2
+version: 1.7.0
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault
@@ -43,7 +43,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-vault/pull/2
   artifacthub.io/images: |
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
     - name: ubuntu
       image: artifactory.algol60.net/csm-docker/stable/docker.io/library/ubuntu:focal
     - name: vault

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -31,7 +31,7 @@ nameOverride: ""
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
     pullPolicy: IfNotPresent
 
 # Ingress gateways to allow vault access over


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

* Beau (vshasta2)

### Test description:

I upgraded the cray-vault chart and cray-vault-operator chart. The wait containers use this docker-kubectl image and they completed successfully.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

