### PR TITLE
CASMPET-7207: Add new permissions for the tapms operator role in vault.

### DIFF
--- a/charts/cray-vault/Chart.yaml
+++ b/charts/cray-vault/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-vault
-version: 1.7.0
+version: 1.7.1
 description: Cray Vault for secure secret stores
 keywords:
   - cray-vault

--- a/charts/cray-vault/templates/ingress.yaml
+++ b/charts/cray-vault/templates/ingress.yaml
@@ -25,20 +25,18 @@ OTHER DEALINGS IN THE SOFTWARE.
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: "cray-vault"
+  name: "{{ include "cray-vault.name" . }}"
 spec:
   hosts:
-    - "*"
+    - {{ .Values.ingress.host | quote }}
   {{- with .Values.ingress.gateways }}
   gateways:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   http:
     - match:
-      - uri:
-          prefix: /apis/vault
-      rewrite:
-        uri: ' '
+      - authority:
+          exact: {{ .Values.ingress.host | quote }}
       route:
       - destination:
           host: cray-vault

--- a/charts/cray-vault/templates/vault.yaml
+++ b/charts/cray-vault/templates/vault.yaml
@@ -154,10 +154,14 @@ spec:
       # The minimum policy requirements at this time are:
       # sys/mounts/cray-tenant-* capabilities to permit the creation and removal of tenant transit engines.
       # cray-tenant-* capabilities to permit the creation and removal of tenant transit engine keys.
+      # sys/policy/allow_cray-tenant-* capabilities to permit the creation and removal of authentication policy for tenants.
+      # auth/kubernetes/role/cray-tenant-* capabilities to permit the creation and removal of authentication roles for tenants.
       - name: tapms-operator
         rules: |
           path "sys/mounts/cray-tenant-*" { capabilities = ["read", "update", "delete"] }
           path "cray-tenant-*" { capabilities = ["read", "update", "delete"] }
+          path "auth/kubernetes/role/cray-tenant-*" { capabilities = ["create", "read", "update", "delete"] }
+          path "sys/policy/allow_cray-tenant-*" { capabilities = ["read", "update", "delete"] }
       {{- if .Values.pki.customCA.enabled }}
       # This pki-engine policy is used by cert-manager for 'common' issuers
       # to request leaf certificate signing

--- a/charts/cray-vault/values.yaml
+++ b/charts/cray-vault/values.yaml
@@ -39,6 +39,7 @@ ingress:
   gateways:
     - "services/services-gateway"
     - "services/customer-admin-gateway"
+  host: vault.local
 
 serviceAccountName: "vault"
 


### PR DESCRIPTION
## Summary and Scope

This only adds more permissions to the tapms operator to allow it to create policy and roles for tenant specific transit engines. The only change in how the auth policy works is allowing tapms-operator to create and delete specific policy only for tenant specific endpoints. Vault has no more openings only allowing new policy to be made.

## Issues and Related PRs

* Works on [CASMPET-7207](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7207)

## Testing
### Tested on:

  * Beau

### Test description:

The test was to put the new policy up and see if the tapms-operator has correct permissions.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Low risk as it only opens endpoints that the tapms-operator can access.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

