### PR TITLE
CASMPET-7613 : updating cray-vault-operator CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,22 @@ lint:
 dep-up:
 	CMD="dep up charts/cray-vault-operator" $(MAKE) helm
 	CMD="dep up charts/cray-vault"          $(MAKE) helm
+	$(MAKE) copy-crds
+
+copy-crds:
+	@echo "Copying CRDs from dependency chart to crds directory..."
+	@mkdir -p charts/cray-vault-operator/crds
+	@cd charts/cray-vault-operator/charts && \
+	if [ -f vault-operator-*.tgz ]; then \
+		echo "Extracting dependency chart CRDs..."; \
+		if tar -xzf vault-operator-*.tgz -C ../crds --strip-components 2 vault-operator/crds/crd.yaml; then \
+			echo "CRDs copied successfully"; \
+		else \
+			echo "Warning: Failed to extract CRDs from dependency chart"; \
+		fi; \
+	else \
+		echo "Warning: Dependency chart vault-operator-*.tgz file not found"; \
+	fi
 
 test:
 	docker run --rm \

--- a/charts/cray-vault-operator/Chart.yaml
+++ b/charts/cray-vault-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-vault-operator
-version: 1.5.0
+version: 1.5.1
 description: Cray Vault Operator for secure secret stores
 keywords:
   - cray-vault-operator
@@ -23,7 +23,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-vault/pull/2
   artifacthub.io/images: |
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
     - name: vault-operator
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/bank-vaults/vault-operator:v1.22.5
     - name: bank-vaults

--- a/charts/cray-vault-operator/templates/crd-update-configmap.yaml
+++ b/charts/cray-vault-operator/templates/crd-update-configmap.yaml
@@ -1,0 +1,34 @@
+{{- /*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cray-vault-operator-crd-configmap"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+data:
+  crd.yaml: |-
+    {{- .Files.Get "crds/crd.yaml" | nindent 4 }}

--- a/charts/cray-vault-operator/templates/crd-update-job.yaml
+++ b/charts/cray-vault-operator/templates/crd-update-job.yaml
@@ -1,0 +1,58 @@
+{{- /*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "cray-vault-operator-pre-upgrade-crd-hook"
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      name: "cray-vault-operator-pre-upgrade-crd-hook"
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: "cray-vault-operator"
+      volumes:
+        - name: "cray-vault-operator-crd-configmap"
+          configMap:
+            name: "cray-vault-operator-crd-configmap"
+            defaultMode: 0755
+      restartPolicy: Never
+      containers:
+        - name: cray-vault-operator-pre-upgrade-crd-hook
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          volumeMounts:
+           - name: "cray-vault-operator-crd-configmap"
+             mountPath: /crds
+          command:
+            - '/bin/sh'
+          args:
+            - "-c"
+            - kubectl apply -f /crds/crd.yaml

--- a/charts/cray-vault-operator/templates/crd-update-rbac.yaml
+++ b/charts/cray-vault-operator/templates/crd-update-rbac.yaml
@@ -1,0 +1,60 @@
+{{/*
+MIT License
+
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+## ClusterRole that allows cluster-wide access to manage CRDs 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  creationTimestamp: null
+  name: cray-vault-operator-crd-role
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+---
+## Bind the role to the cray-vault-operator service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cray-vault-operator-crd-rolebinding
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cray-vault-operator-crd-role
+subjects:
+- kind: ServiceAccount
+  name: "cray-vault-operator"
+  namespace: {{ .Release.Namespace }}

--- a/charts/cray-vault-operator/values.yaml
+++ b/charts/cray-vault-operator/values.yaml
@@ -4,8 +4,8 @@
 
 kubectl:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.24.17
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
+    tag: 1.33.1
     pullPolicy: IfNotPresent
 
 vault-operator:


### PR DESCRIPTION
## Summary and Scope

When comparing the vaults.vault.banzaicloud.com CRD on a fresh CSM 1.7 installation versus a CSM 1.6 → 1.7 upgrade, it was observed that the CRD was not updated during the upgrade process.

This PR addresses the issue by updating the CRD using a Helm ConfigMap with a pre-upgrade hook.

Additionally, the docker-kubectl image has been replaced with bitnami/kubectl to use a more up-to-date version of the image, similar to the approach taken during the Velero upgrade.

## Issues and Related PRs

* Resolves [CASMPET-7613](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7613)

## Testing

tested by installing unstable chart version.

### Tested on:

  * starlord

## Risks and Mitigations

No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

