### PR TITLE
CASMPET-7673: Only create vault-operator-psp rolebinding if PSP capability exists

### DIFF
--- a/charts/cray-vault-operator/Chart.yaml
+++ b/charts/cray-vault-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-vault-operator
-version: 1.5.1
+version: 1.5.2
 description: Cray Vault Operator for secure secret stores
 keywords:
   - cray-vault-operator
@@ -23,7 +23,7 @@ annotations:
           url: https://github.com/Cray-HPE/cray-vault/pull/2
   artifacthub.io/images: |
     - name: kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
     - name: vault-operator
       image: artifactory.algol60.net/csm-docker/stable/ghcr.io/bank-vaults/vault-operator:v1.22.5
     - name: bank-vaults

--- a/charts/cray-vault-operator/templates/rbac.yaml
+++ b/charts/cray-vault-operator/templates/rbac.yaml
@@ -1,4 +1,28 @@
-# RoleBinding for PSP in vault namespace
+{{/*
+MIT License
+
+(C) Copyright [2025] Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,6 +36,7 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:serviceaccounts:{{ $op := index .Values "vault-operator" }}{{ $op.watchNamespace}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/cray-vault-operator/values.yaml
+++ b/charts/cray-vault-operator/values.yaml
@@ -4,8 +4,8 @@
 
 kubectl:
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl
-    tag: 1.33.1
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.32.2
     pullPolicy: IfNotPresent
 
 vault-operator:


### PR DESCRIPTION
## Summary and Scope

CASMPET-7673: Only create vault-operator-psp rolebinding if PSP capability exists
  * Use docker-kubectl 1.32.2 instead of docker.io/bitnami/kubectl 1.33.1 in cray-vault-operator


## Testing
Tested on `beau`

Rolled back to `cray-vault-operator-1.5.1` to create `vault-psp` rolebinding.
```
pit:~/studenym/cray-vault-operator # helm rollback -n vault cray-vault-operator 1
Rollback was a success! Happy Helming!
pit:~/studenym/cray-vault-operator # helm history -n vault cray-vault-operator
REVISION	UPDATED                 	STATUS    	CHART                    	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:08:47 2025	superseded	cray-vault-operator-1.5.1	1.22.5     	Install complete
2       	Wed Sep 24 15:22:27 2025	deployed  	cray-vault-operator-1.5.1	1.22.5     	Rollback to 1
pit:~/studenym/cray-vault-operator # kubectl get rolebinding -A | grep psp
services         cray-node-discovery                                                        ClusterRole/privileged-psp                                     4d18h
spire            tpm-provisioner-psp                                                        ClusterRole/restricted-transition-net-raw-psp                  20h
vault            spire-intermediate-psp                                                     ClusterRole/restricted-transition-psp                          18h
vault            tpm-intermediate-psp                                                       ClusterRole/restricted-transition-psp                          18h
vault            vault-psp                                                                  ClusterRole/privileged-psp                                     28s
pit:~/studenym/cray-vault-operator # kubectl get rolebinding -n vault | grep vault-psp
vault-psp                      ClusterRole/privileged-psp              83s
pit:~/studenym/cray-vault-operator #
```

Upgraded to unstable `cray-vault-operator-1.5.2` chart.  The `docker-kubectl:1.32.2` image is used in the pre-upgrade and post-upgrade hooks.
```
pit:~/studenym/cray-vault-operator # helm upgrade -n vault cray-vault-operator cray-vault-operator-1.5.2-20250924145350+39801ca.tgz
Release "cray-vault-operator" has been upgraded. Happy Helming!
NAME: cray-vault-operator
LAST DEPLOYED: Wed Sep 24 15:26:30 2025
NAMESPACE: vault
STATUS: deployed
REVISION: 3
TEST SUITE: None
NOTES:
A Cray-specific Vault Operator chart
pit:~/studenym/cray-vault-operator # helm history -n vault cray-vault-operator
REVISION	UPDATED                 	STATUS    	CHART                                           	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:08:47 2025	superseded	cray-vault-operator-1.5.1                       	1.22.5     	Install complete
2       	Wed Sep 24 15:22:27 2025	superseded	cray-vault-operator-1.5.1                       	1.22.5     	Rollback to 1
3       	Wed Sep 24 15:26:30 2025	deployed  	cray-vault-operator-1.5.2-20250924145350+39801ca	1.22.5     	Upgrade complete
pit:~/studenym/cray-vault-operator #
```

Check to see if `vault-psp` rolebinding exists with the new chart. 
```
pit:~/studenym/cray-vault-operator # kubectl get rolebinding -n vault
NAME                           ROLE                                    AGE
cray-vault-jobs-role-binding   Role/cray-vault-jobs-role               44d
spire-intermediate-psp         ClusterRole/restricted-transition-psp   18h
tpm-intermediate-psp           ClusterRole/restricted-transition-psp   18h
vault-secrets                  Role/vault-secrets                      44d
pit:~/studenym/cray-vault-operator # kubectl get rolebinding -n vault | grep vault-psp
pit:~/studenym/cray-vault-operator #
```

Rollback to `cray-vault-operator:1.5.1` and check if `vault-psp` is recreated.
```
pit:~/studenym/cray-vault-operator # helm rollback -n vault cray-vault-operator 1
Rollback was a success! Happy Helming!
pit:~/studenym/cray-vault-operator # helm history -n vault cray-vault-operator
REVISION	UPDATED                 	STATUS    	CHART                                           	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:08:47 2025	superseded	cray-vault-operator-1.5.1                       	1.22.5     	Install complete
2       	Wed Sep 24 15:22:27 2025	superseded	cray-vault-operator-1.5.1                       	1.22.5     	Rollback to 1
3       	Wed Sep 24 15:26:30 2025	superseded	cray-vault-operator-1.5.2-20250924145350+39801ca	1.22.5     	Upgrade complete
4       	Wed Sep 24 15:32:36 2025	deployed  	cray-vault-operator-1.5.1                       	1.22.5     	Rollback to 1
pit:~/studenym/cray-vault-operator # kubectl get rolebinding -n vault | grep vault-psp
vault-psp                      ClusterRole/privileged-psp              16s
pit:~/studenym/cray-vault-operator #
```

## Risks and Mitigations
Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

